### PR TITLE
locking com.onfido.sdk.capture:onfido-capture-sdk to 4.9.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.onfido.sdk.capture:onfido-capture-sdk:+'
+    implementation 'com.onfido.sdk.capture:onfido-capture-sdk:4.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:3.10.0'
 }


### PR DESCRIPTION
Version 5.0.0 introduces breaking changes https://github.com/onfido/onfido-android-sdk/commit/450e84b4020e724a0e80052463615d070a1c3347

Mainly the removal of Applicant which is heavily used.

closes https://github.com/LykkeCorp/profiles/issues/562